### PR TITLE
Feature/cmp 1160 allow iwh zip files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Any argument is valid, but most are ignored. These are the expected ones (all ot
 - `--exclude PATH` Can be added multiple times. Will ignore listed files in vue source directory (paths should be relative to it)
 - `--icon PATH` Icon file to add to the zipped XUI and pointed to in the metadata.
 
-In addition, any other argument that's prepended with `met` gets added to the metadata. Important examples and how the content library or CloudBolt uses them(note the underscores in the keys):
+In addition, any other argument that's prepended with `met` gets added to the metadata. Important examples and how the content library or CloudBolt uses them (note the underscores in the keys):
 
 - `--met_description "TEXT"` Content Library Description. Make sure to quote arguments that have spaces in them.
 - `--met_label LABEL` Human-readable version of the name.
@@ -40,6 +40,7 @@ In addition, any other argument that's prepended with `met` gets added to the me
 - `--met_minimum_version_required VERSION` Minimum CloudBolt version number for the XUI
 - `--met_maximum_version_required VERSION` Maximum CloudBolt version number for the XUI
 - `--met_last_updated YYYY-MM-DD` Defaults to today unless specified
+- `--met_inbound_web_hook_dependencies` Array of inbound webhooks (iwh) files that are included with this XUI
 
 Paths are relative to the directory in which the command is run (this is the project root if run as an npm script) unless otherwise stated above.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Any argument is valid, but most are ignored. These are the expected ones (all ot
 - `--id ID` **Required** CUI Global id in the form of `XUI-xxxxxxxx` where x is any number or lowercase letter.
 - `--vue_source DIRECTORY` Source files directory for built vue files. Defaults to `dist`
 - `--xui_src DIRECTORY` Source for xui files like `views.py` and others. Defaults to `xui/src`
+- `--additional_files_src DIRECTORY` Source for additional files to be bundled into the final zip. Defaults to `xui/additional_files`
 - `--output DIRECTORY` Where the xui gets saved. Defaults to `xui/dist`
 - `--exclude PATH` Can be added multiple times. Will ignore listed files in vue source directory (paths should be relative to it)
 - `--icon PATH` Icon file to add to the zipped XUI and pointed to in the metadata.
@@ -40,7 +41,7 @@ In addition, any other argument that's prepended with `met` gets added to the me
 - `--met_minimum_version_required VERSION` Minimum CloudBolt version number for the XUI
 - `--met_maximum_version_required VERSION` Maximum CloudBolt version number for the XUI
 - `--met_last_updated YYYY-MM-DD` Defaults to today unless specified
-- `--met_inbound_web_hook_dependencies` Optional array of inbound web hook .zip files that are included dependencies for the XUI
+- `--met_inbound_web_hook_dependencies` Optional array of inbound web hook ZIP files that are dependencies for the XUI. ZIP files should be in `xui/additional_files` or the custom directory argument provided to `--additional_files_src` 
 
 Paths are relative to the directory in which the command is run (this is the project root if run as an npm script) unless otherwise stated above.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ In addition, any other argument that's prepended with `met` gets added to the me
 - `--met_minimum_version_required VERSION` Minimum CloudBolt version number for the XUI
 - `--met_maximum_version_required VERSION` Maximum CloudBolt version number for the XUI
 - `--met_last_updated YYYY-MM-DD` Defaults to today unless specified
-- `--met_inbound_web_hook_dependencies` Array of inbound webhooks (iwh) files that are included with this XUI
+- `--met_inbound_web_hook_dependencies` Optional array of inbound web hook .zip files that are included dependencies for the XUI
 
 Paths are relative to the directory in which the command is run (this is the project root if run as an npm script) unless otherwise stated above.
 
@@ -59,7 +59,11 @@ As a convenience, you can also supply arguments in a `configXui` field in `packa
     "met_description": "Next-Gen Consumer UI.\n\nAn end-user focused interface that brings a modern, responsive, snappy experience to CloudBolt's best-in-class functionality.\n\nCurrently in BETA.",
     "met_label": "CUI Beta",
     "met_maximum_version_required": "",
-    "met_minimum_version_required": "2022.4.2"
+    "met_minimum_version_required": "2022.4.2",
+    "met_inbound_web_hook_dependencies": [
+      "inbound_web_hook_upload_file.zip",
+      "inbound_web_hook_download_file.zip"
+    ],
   },
   "scripts": {
     ...

--- a/bin/index.js
+++ b/bin/index.js
@@ -70,6 +70,12 @@ function parseConfig(args) {
     config.iconFilename = path.basename(args.icon)
   }
 
+  // add iwh file info if inbound web hooks are present
+  if (args.met_inbound_web_hook_dependencies) {
+    config.iwhFiles = args.met_inbound_web_hook_dependencies
+    config.iwhPath = args.xui_src ? args.xui_src : defaultConfig.xuiSrcDir
+  }
+
   // Metadata is any argument whose key begins with `met-`. Strip the prefix and
   // add it to the config.
   const extraMetadata = Object.entries(args).reduce(
@@ -344,7 +350,9 @@ function zipContentLibraryPackageFiles({
   outputDir,
   name,
   iconPath,
-  iconFilename
+  iconFilename,
+  iwhFiles,
+  iwhPath,
 }) {
   return new Promise((resolve, reject) => {
     const zipFile = `${outputDir}/${name}.zip`
@@ -370,6 +378,12 @@ function zipContentLibraryPackageFiles({
     archive.file(metaFile, { name: `${name}.json` })
     if (iconPath) {
       archive.file(iconPath, { name: iconFilename })
+    }
+
+    if (iwhFiles) {
+      iwhFiles.forEach((file) => {
+        archive.file(`${iwhPath}/${file}`, {name: file})
+      })
     }
 
     archive.finalize().then(() => resolve(outputFilePath))

--- a/bin/index.js
+++ b/bin/index.js
@@ -24,6 +24,7 @@ const load = require('load-pkg')
 const defaultConfig = {
   vueSrcDir: 'dist',
   xuiSrcDir: 'xui/src',
+  additionalFilesDir: 'xui/additional_files',
   outputDir: 'xui/dist',
   extraMetadata: {
     enabled: true
@@ -70,10 +71,9 @@ function parseConfig(args) {
     config.iconFilename = path.basename(args.icon)
   }
 
-  // add iwh file info if inbound web hooks are present
-  if (args.met_inbound_web_hook_dependencies) {
-    config.iwhFiles = args.met_inbound_web_hook_dependencies
-    config.iwhPath = args.xui_src ? args.xui_src : defaultConfig.xuiSrcDir
+  // add extra files from directory if specified, otherwise default to `xui/additional_files`
+  if (args.additional_files_src) {
+    config.additionalFilesDir = args.additional_files_src
   }
 
   // Metadata is any argument whose key begins with `met-`. Strip the prefix and
@@ -351,8 +351,7 @@ function zipContentLibraryPackageFiles({
   name,
   iconPath,
   iconFilename,
-  iwhFiles,
-  iwhPath,
+  additionalFilesDir
 }) {
   return new Promise((resolve, reject) => {
     const zipFile = `${outputDir}/${name}.zip`
@@ -380,11 +379,7 @@ function zipContentLibraryPackageFiles({
       archive.file(iconPath, { name: iconFilename })
     }
 
-    if (iwhFiles) {
-      iwhFiles.forEach((file) => {
-        archive.file(`${iwhPath}/${file}`, {name: file})
-      })
-    }
+    archive.directory(additionalFilesDir, false)
 
     archive.finalize().then(() => resolve(outputFilePath))
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudbolt/xui-packager",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudbolt/xui-packager",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "archiver": "^5.3.1",
         "fs-extra": "^11.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudbolt/xui-packager",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "CloudBolt Javascript package for bundling XUI content",
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
Ticket - [CMP-1160](https://cloudbolt.atlassian.net/browse/CMP-1160) as followup/support for [CMP-127](https://cloudbolt.atlassian.net/browse/CMP-127)
Engineer @tropotorres 
Tested locally on my s3_bucket_browser instance (was not able to test applet zip on upload yet, however this is based off how the zip file/folder structure looks when you download an applet with iwh dependencies from HUI's extensions manager)

I'm not 100% sure of the README changes, I just thought it'd be useful to note the IWHs

[CMP-1160]: https://cloudbolt.atlassian.net/browse/CMP-1160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CMP-127]: https://cloudbolt.atlassian.net/browse/CMP-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ